### PR TITLE
Support for binary, barrier, notification, and door lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,5 @@ dmypy.json
 #PyCharm
 .idea/
 isy_homie.yml
+
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -11,41 +11,55 @@ Currently supports
     ISY Programs
     ISY Variables
 
-To start as a service on raspbian 
 
-Create isy_homie.yml in /etc using the following settings:
+To install:
+```
+pip3 install ISY994-Homie4-Bridge --user 
+```
+
+To start as a service on raspbian:
+
+Create isy_homie.yml in /home/pi using the following settings:
 
 
 ```yaml
 isy:
   url: xxx.xxx.xxx.xxx
-  username: xxxxx
-  password: xxxxx
+  username: admin
+  password: admin
 
 mqtt:
-  MQTT_BROKER: broker
+  MQTT_BROKER: localhost
   MQTT_PORT: 1883
   MQTT_USERNAME: null
   MQTT_PASSWORD: null
   MQTT_SHARE_CLIENT: true
-  ```
 
-  Create isy-homie.service in /etc/systemd/system
+logging:
+  enable: true
+  level: ERROR
+```
 
-  ```service
+Create `isy-homie.service` in `/etc/systemd/system`
+
+```service
 [Unit]
-Description=ISY995 Homie
+Description=ISY994 Homie
 After=multi-user.target
 
 [Service]
 User=pi
 Type=simple
-ExecStart=/usr/bin/python3 /usr/local/bin/isy_homie_start.py
+WorkingDirectory=/home/pi
+ExecStart=/usr/bin/python3 /home/pi/.local/bin/isy_homie_start.py
 Restart=on-abort
 
 [Install]
 WantedBy=multi-user.target
 ```
 
-
-
+Then, start the service and enable launch on start up:
+```sh
+sudo service start isy-homie
+sudo systemctl enable isy-homie
+```

--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ Currently supports
     ISY Variables
 
 
+Example usage:
+```sh
+mosquitto_pub -t 'homie/switch-334455a/switch/switch/set' -m false # turn light off
+mosquitto_pub -t 'homie/switch-334455a/switch/switch/set' -m true # turn light on
+```
+
 To install:
 ```
 pip3 install ISY994-Homie4-Bridge --user 

--- a/isy-homie.service
+++ b/isy-homie.service
@@ -5,7 +5,8 @@ After=multi-user.target
 [Service]
 User=pi
 Type=simple
-ExecStart=/usr/bin/python3 /usr/local/bin/isy_homie_start.py
+WorkingDirectory=/home/pi
+ExecStart=/usr/bin/python3 /home/pi/.local/bin/isy_homie_start.py
 Restart=on-abort
 
 [Install]

--- a/isy_homie.yml
+++ b/isy_homie.yml
@@ -4,7 +4,7 @@ isy:
   password: admin
 
 mqtt:
-  MQTT_BROKER: openhab
+  MQTT_BROKER: localhost
   MQTT_PORT: 1883
   MQTT_USERNAME: null
   MQTT_PASSWORD: null

--- a/isy_homie/bridge.py
+++ b/isy_homie/bridge.py
@@ -72,7 +72,7 @@ class Bridge(object):
         mqtt_settings=None,
         log_settings = LOG_SETTINGS,
     ):
-        
+
         if log_settings is not None and log_settings['enable'] is True:
             logging.basicConfig(level=log_settings ['level'],handlers=[file_handler,console_handler])
 
@@ -111,32 +111,36 @@ class Bridge(object):
     def _device_event_handler(self, device, event, *args):
         logger.debug("Device event {}".format(device.name, event, args))
         if event == "add":
+            bridge_device = None
             if device.device_type == "binary":
-                device = Binary(device, self.homie_settings, self.mqtt_settings)
+                bridge_device = Binary(device, self.homie_settings, self.mqtt_settings)
             elif device.device_type == "barrier":
-                device = Barrier(device, self.homie_settings, self.mqtt_settings)
+                bridge_device = Barrier(device, self.homie_settings, self.mqtt_settings)
             elif device.device_type == "contact":
-                device = Contact(device, self.homie_settings, self.mqtt_settings)
+                bridge_device = Contact(device, self.homie_settings, self.mqtt_settings)
             elif device.device_type == "dimmer":
-                device = Dimmer(device, self.homie_settings, self.mqtt_settings)
+                bridge_device = Dimmer(device, self.homie_settings, self.mqtt_settings)
             elif device.device_type == "fan":
-                device = Fan(device, self.homie_settings, self.mqtt_settings)
+                bridge_device = Fan(device, self.homie_settings, self.mqtt_settings)
             elif device.device_type == "lock":
-                device = Door_Lock(device, self.homie_settings, self.mqtt_settings)
+                bridge_device = Door_Lock(device, self.homie_settings, self.mqtt_settings)
             elif device.device_type == "notification":
-                device = Notification_Sensor(device, self.homie_settings, self.mqtt_settings)
+                bridge_device = Notification_Sensor(device, self.homie_settings, self.mqtt_settings)
             elif device.device_type == "thermostat":
-                device = Thermostat(device, self.homie_settings, self.mqtt_settings)
+                bridge_device = Thermostat(device, self.homie_settings, self.mqtt_settings)
             elif device.device_type == "siren":
-                device = Siren(device, self.homie_settings, self.mqtt_settings)
+                bridge_device = Siren(device, self.homie_settings, self.mqtt_settings)
             elif device.device_type == "switch":
-                device = Switch(device, self.homie_settings, self.mqtt_settings)
+                bridge_device = Switch(device, self.homie_settings, self.mqtt_settings)
             elif device.device_type == "controller":
-                device = Controller_Action(
+                bridge_device = Controller_Action(
                     device, self.homie_settings, self.mqtt_settings
                 )
 
-            self.homie_devices[device.get_homie_device_id()] = device
+            if bridge_device is not None:
+                self.homie_devices[bridge_device.get_homie_device_id()] = bridge_device
+            else:
+                logger.warning("Unknown device {}".format(device))
 
     def _scene_event_handler(self, device, event, *args):
         logger.debug("Scene event {}".format(device.name, event))

--- a/isy_homie/bridge.py
+++ b/isy_homie/bridge.py
@@ -26,17 +26,21 @@ import isy994
 import homie
 import isy_homie
 
-from .devices.switch import Switch
-from .devices.dimmer import Dimmer
-from .devices.fan import Fan
+from .devices.barrier import Barrier
+from .devices.binary import Binary
 from .devices.contact import Contact
 from .devices.controller_action import Controller_Action
-from .devices.scene import Scene
-from .devices.variable import Variable
-from .devices.program import Program
-from .devices.thermostat import Thermostat
-from .devices.siren import Siren
+from .devices.dimmer import Dimmer
+from .devices.door_lock import Door_Lock
+from .devices.fan import Fan
 from .devices.isy_controller import ISY_Controller
+from .devices.notification_sensor import Notification_Sensor
+from .devices.program import Program
+from .devices.scene import Scene
+from .devices.siren import Siren
+from .devices.switch import Switch
+from .devices.thermostat import Thermostat
+from .devices.variable import Variable
 
 HOMIE_SETTINGS = {
     "update_interval": 60,
@@ -107,18 +111,26 @@ class Bridge(object):
     def _device_event_handler(self, device, event, *args):
         logger.debug("Device event {}".format(device.name, event, args))
         if event == "add":
-            if device.device_type == "switch":
-                device = Switch(device, self.homie_settings, self.mqtt_settings)
+            if device.device_type == "binary":
+                device = Binary(device, self.homie_settings, self.mqtt_settings)
+            elif device.device_type == "barrier":
+                device = Barrier(device, self.homie_settings, self.mqtt_settings)
+            elif device.device_type == "contact":
+                device = Contact(device, self.homie_settings, self.mqtt_settings)
             elif device.device_type == "dimmer":
                 device = Dimmer(device, self.homie_settings, self.mqtt_settings)
             elif device.device_type == "fan":
                 device = Fan(device, self.homie_settings, self.mqtt_settings)
-            elif device.device_type == "contact":
-                device = Contact(device, self.homie_settings, self.mqtt_settings)
+            elif device.device_type == "lock":
+                device = Door_Lock(device, self.homie_settings, self.mqtt_settings)
+            elif device.device_type == "notification":
+                device = Notification_Sensor(device, self.homie_settings, self.mqtt_settings)
             elif device.device_type == "thermostat":
                 device = Thermostat(device, self.homie_settings, self.mqtt_settings)
             elif device.device_type == "siren":
                 device = Siren(device, self.homie_settings, self.mqtt_settings)
+            elif device.device_type == "switch":
+                device = Switch(device, self.homie_settings, self.mqtt_settings)
             elif device.device_type == "controller":
                 device = Controller_Action(
                     device, self.homie_settings, self.mqtt_settings

--- a/isy_homie/devices/barrier.py
+++ b/isy_homie/devices/barrier.py
@@ -1,0 +1,32 @@
+#! /usr/bin/env python
+
+from homie.device_barrier import Device_Barrier
+from .base import Base
+
+
+class Barrier(Base, Device_Barrier):
+    def __init__(self, isy_device=None, homie_settings=None, mqtt_settings=None):
+
+        Base.__init__(self, isy_device)
+
+        Device_Barrier.__init__(
+            self,
+            self.get_homie_device_id(),
+            isy_device.name,
+            homie_settings,
+            mqtt_settings,
+        )
+
+        barrier = self.isy_device.get_property("barrier")
+        if barrier is not None:
+            self.property_change("barrier", barrier)
+
+    def get_homie_device_id(self):
+        return "barrier-" + Base.get_homie_device_id(self)
+
+    def property_change(self, property_, value):
+        if property_ == "barrier":
+            self.update_barrier(value.upper())
+
+        Base.property_change(self, property_, value)
+

--- a/isy_homie/devices/binary.py
+++ b/isy_homie/devices/binary.py
@@ -1,0 +1,32 @@
+#! /usr/bin/env python
+
+from homie.device_binary import Device_Binary
+from .base import Base
+
+
+class Binary(Base, Device_Binary):
+    def __init__(self, isy_device=None, homie_settings=None, mqtt_settings=None):
+
+        Base.__init__(self, isy_device)
+
+        Device_Binary.__init__(
+            self,
+            self.get_homie_device_id(),
+            isy_device.name,
+            homie_settings,
+            mqtt_settings,
+        )
+
+        binary = self.isy_device.get_property("binary")
+        if binary is not None:
+            self.property_change("binary", binary)
+
+    def get_homie_device_id(self):
+        return "binary-" + Base.get_homie_device_id(self)
+
+    def property_change(self, property_, value):
+        if property_ == "binary":
+            self.update_binary(value.upper())
+
+        Base.property_change(self, property_, value)
+

--- a/isy_homie/devices/controller_action.py
+++ b/isy_homie/devices/controller_action.py
@@ -1,6 +1,5 @@
 #! /usr/bin/env python
 
-
 from homie.device_base import Device_Base
 from homie.node.node_base import Node_Base
 from homie.node.property.property_string import Property_String

--- a/isy_homie/devices/door_lock.py
+++ b/isy_homie/devices/door_lock.py
@@ -1,0 +1,38 @@
+#! /usr/bin/env python
+
+from homie.device_lock import Device_Lock
+from .base import Base
+
+
+class Door_Lock(Base, Device_Lock):
+    def __init__(self, isy_device=None, homie_settings=None, mqtt_settings=None):
+
+        Base.__init__(self, isy_device)
+
+        Device_Lock.__init__(
+            self,
+            self.get_homie_device_id(),
+            isy_device.name,
+            homie_settings,
+            mqtt_settings,
+        )
+
+        lock = self.isy_device.get_property("lock")
+        if lock is not None:
+            self.property_change("lock", lock)
+
+    def get_homie_device_id(self):
+        return "lock-" + Base.get_homie_device_id(self)
+
+    def lock(self):
+        self.isy_device.lock()
+
+    def unlock(self):
+        self.isy_device.unlock()
+
+    def property_change(self, property_, value):
+        if property_ == "lock":
+            self.update_lock(value.upper())
+
+        Base.property_change(self, property_, value)
+

--- a/isy_homie/devices/notification_sensor.py
+++ b/isy_homie/devices/notification_sensor.py
@@ -1,0 +1,31 @@
+#! /usr/bin/env python
+
+from homie.device_notification import Device_Notification
+from .base import Base
+
+
+class Notification_Sensor(Base, Device_Notification):
+    def __init__(self, isy_device=None, homie_settings=None, mqtt_settings=None):
+
+        Base.__init__(self, isy_device)
+
+        Device_Notification.__init__(
+            self,
+            self.get_homie_device_id(),
+            isy_device.name,
+            homie_settings,
+            mqtt_settings,
+        )
+
+        notification = self.isy_device.get_property("notification")
+        if notification is not None:
+            self.property_change("notification", notification)
+
+    def get_homie_device_id(self):
+        return "notification-" + Base.get_homie_device_id(self)
+
+    def property_change(self, property_, value):
+        if property_ == "notification":
+            self.update_notification(value.upper())
+
+        Base.property_change(self, property_, value)


### PR DESCRIPTION
@mjcumming I think there are some more changes needed to support all of the values, but this should be a start. Welcome any changes (or, let me know what I've done incorrectly and will make needed changes).

Barrier/binary/notification are read-only, but lock should be able to get triggered.

Have also made some minor edits to your install `README` based on my experience on RPI.